### PR TITLE
Update iam_pipes.tf to support step function sync executions

### DIFF
--- a/iam_pipes.tf
+++ b/iam_pipes.tf
@@ -227,7 +227,8 @@ locals {
 
     step_functions = {
       actions = [
-        "states:StartExecution"
+        "states:StartExecution",
+        "states:StartSyncExecution"
       ]
     }
 


### PR DESCRIPTION
It looks like we're missing the states:StartSyncExecution action so we can execute step functions using the REQUEST_RESPONSE invocation_type